### PR TITLE
서버 헬스 체킹

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,12 @@ dependencies {
     //spring dest docs
     asciidoctorExt 'org.springframework.restdocs:spring-restdocs-asciidoctor'
     testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
+
+    // retry
+    implementation 'org.springframework.retry:spring-retry'
+
+    // mockwebserver
+    testImplementation("com.squareup.okhttp3:mockwebserver:4.10.0")
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/healthcheck/api/v1/controller/HealthCheckController.java
+++ b/src/main/java/com/example/healthcheck/api/v1/controller/HealthCheckController.java
@@ -1,0 +1,24 @@
+package com.example.healthcheck.api.v1.controller;
+
+import com.example.healthcheck.api.v1.response.Response;
+import com.example.healthcheck.service.health.HealthRecordSaver;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/check")
+@RequiredArgsConstructor
+public class HealthCheckController {
+
+    private final HealthRecordSaver healthRecordSaver;
+
+    @PostMapping("/{serverId}")
+    public Response<Void> check(@PathVariable Long serverId){
+        healthRecordSaver.saveRecord(serverId);
+        return Response.success();
+    }
+
+}

--- a/src/main/java/com/example/healthcheck/config/RetryConfig.java
+++ b/src/main/java/com/example/healthcheck/config/RetryConfig.java
@@ -1,0 +1,9 @@
+package com.example.healthcheck.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.retry.annotation.EnableRetry;
+
+@Configuration
+@EnableRetry
+public class RetryConfig {
+}

--- a/src/main/java/com/example/healthcheck/entity/health/HealthRecord.java
+++ b/src/main/java/com/example/healthcheck/entity/health/HealthRecord.java
@@ -1,0 +1,48 @@
+package com.example.healthcheck.entity.health;
+
+import com.example.healthcheck.entity.common.BaseTimeEntity;
+import com.example.healthcheck.entity.server.Server;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.Objects;
+
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class HealthRecord extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "health_record_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "server_id")
+    private Server server;
+
+    @Enumerated(EnumType.STRING)
+    private HealthStatus healthStatus;
+
+    @Builder
+    public HealthRecord(Server server, HealthStatus healthStatus) {
+        this.server = server;
+        this.healthStatus = healthStatus;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof HealthRecord that)) return false;
+        return this.getId() != null && Objects.equals(id, that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
+}

--- a/src/main/java/com/example/healthcheck/entity/health/HealthStatus.java
+++ b/src/main/java/com/example/healthcheck/entity/health/HealthStatus.java
@@ -1,0 +1,11 @@
+package com.example.healthcheck.entity.health;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum HealthStatus {
+    SUCCESS("success") , FAIL("fail");
+    private final String text;
+}

--- a/src/main/java/com/example/healthcheck/entity/server/EndPointHttpMethod.java
+++ b/src/main/java/com/example/healthcheck/entity/server/EndPointHttpMethod.java
@@ -1,8 +1,14 @@
 package com.example.healthcheck.entity.server;
 
 import lombok.Getter;
+import org.springframework.http.HttpMethod;
 
 @Getter
 public enum EndPointHttpMethod {
-    GET
+    GET;
+
+    public HttpMethod convertHttpMethod(){
+        if(this == GET) return HttpMethod.GET;
+        return null;
+    }
 }

--- a/src/main/java/com/example/healthcheck/entity/server/Server.java
+++ b/src/main/java/com/example/healthcheck/entity/server/Server.java
@@ -6,7 +6,9 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
+import org.springframework.web.util.UriComponentsBuilder;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -58,7 +60,16 @@ public class Server extends BaseTimeEntity {
         saveQueryParams(params);
     }
 
+    public String getUrl(){
+        return UriComponentsBuilder.fromHttpUrl(host)
+                .path(path)
+                .queryParams(toPrams())
+                .build()
+                .toString();
+    }
+
     private void saveQueryParams(MultiValueMap<String,String> params){
+        if(params == null) return;
         for(var key : params.keySet()){
             saveQueryParams(key,params.get(key));
         }
@@ -72,6 +83,14 @@ public class Server extends BaseTimeEntity {
                     .server(this)
                     .build());
         }
+    }
+
+    private MultiValueMap<String,String> toPrams(){
+        MultiValueMap<String,String> multiValueMap = new LinkedMultiValueMap<>();
+        for(var element : queryParams){
+            multiValueMap.add(element.getKey(),element.getValue());
+        }
+        return multiValueMap;
     }
 
     @Override

--- a/src/main/java/com/example/healthcheck/exception/ErrorCode.java
+++ b/src/main/java/com/example/healthcheck/exception/ErrorCode.java
@@ -7,7 +7,9 @@ import org.springframework.http.HttpStatus;
 @Getter
 @AllArgsConstructor
 public enum ErrorCode {
-    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "invalid Token")
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "invalid Token"),
+    NOT_FOUND_SERVER(HttpStatus.NOT_FOUND, "Not Found Server"),
+    HEALTH_CHECK_FAIL(HttpStatus.REQUEST_TIMEOUT,"health check fail")
     ;
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/example/healthcheck/repository/health/HealthRecordRepository.java
+++ b/src/main/java/com/example/healthcheck/repository/health/HealthRecordRepository.java
@@ -1,0 +1,7 @@
+package com.example.healthcheck.repository.health;
+
+import com.example.healthcheck.entity.health.HealthRecord;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface HealthRecordRepository extends JpaRepository<HealthRecord,Long> {
+}

--- a/src/main/java/com/example/healthcheck/service/common/DefaultEntityFinder.java
+++ b/src/main/java/com/example/healthcheck/service/common/DefaultEntityFinder.java
@@ -1,0 +1,34 @@
+package com.example.healthcheck.service.common;
+
+import com.example.healthcheck.entity.server.Server;
+import com.example.healthcheck.exception.ErrorCode;
+import com.example.healthcheck.exception.HealthCheckException;
+import com.example.healthcheck.repository.health.HealthRecordRepository;
+import com.example.healthcheck.repository.server.ServerRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class DefaultEntityFinder implements EntityFinder{
+    private final ServerRepository serverRepository;
+    private final HealthRecordRepository healthRecordRepository;
+
+    @Override
+    public <T> T findOrElseThrow(Long id, Class<T> clazz) {
+        return findWithCheckClassType(id,clazz);
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T> T findWithCheckClassType(Long id, Class<T> clazz){
+        if(clazz.isAssignableFrom(Server.class)) return (T)findOrElseThrow(id);
+        throw new IllegalStateException("지원하지 않는 클래스 타입입니다.");
+    }
+
+    private Server findOrElseThrow(Long id){
+        return serverRepository.findById(id).orElseThrow(()-> new HealthCheckException(ErrorCode.NOT_FOUND_SERVER));
+    }
+
+}

--- a/src/main/java/com/example/healthcheck/service/common/EntityFinder.java
+++ b/src/main/java/com/example/healthcheck/service/common/EntityFinder.java
@@ -1,0 +1,5 @@
+package com.example.healthcheck.service.common;
+
+public interface EntityFinder {
+    <T> T findOrElseThrow(Long id , Class<T> clazz);
+}

--- a/src/main/java/com/example/healthcheck/service/health/DefaultHealthChecker.java
+++ b/src/main/java/com/example/healthcheck/service/health/DefaultHealthChecker.java
@@ -1,0 +1,32 @@
+package com.example.healthcheck.service.health;
+
+import com.example.healthcheck.entity.server.Server;
+import com.example.healthcheck.exception.ErrorCode;
+import com.example.healthcheck.exception.HealthCheckException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.retry.annotation.Retryable;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class DefaultHealthChecker implements HealthChecker{
+
+    private final RestTemplate restTemplate;
+
+    @Retryable(
+            retryFor = HealthCheckException.class,
+            maxAttempts = 3
+    )
+    public void check(Server server){
+        try{
+            restTemplate.getForObject(server.getUrl(), String.class);
+        }catch (RestClientException e){
+            throw new HealthCheckException(ErrorCode.HEALTH_CHECK_FAIL);
+        }
+    }
+
+}

--- a/src/main/java/com/example/healthcheck/service/health/HealthChecker.java
+++ b/src/main/java/com/example/healthcheck/service/health/HealthChecker.java
@@ -1,0 +1,7 @@
+package com.example.healthcheck.service.health;
+
+import com.example.healthcheck.entity.server.Server;
+
+public interface HealthChecker {
+    void check(Server server);
+}

--- a/src/main/java/com/example/healthcheck/service/health/HealthRecordSaver.java
+++ b/src/main/java/com/example/healthcheck/service/health/HealthRecordSaver.java
@@ -1,0 +1,41 @@
+package com.example.healthcheck.service.health;
+
+import com.example.healthcheck.entity.health.HealthRecord;
+import com.example.healthcheck.entity.health.HealthStatus;
+import com.example.healthcheck.entity.server.Server;
+import com.example.healthcheck.exception.HealthCheckException;
+import com.example.healthcheck.repository.health.HealthRecordRepository;
+import com.example.healthcheck.service.common.EntityFinder;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+@Transactional
+public class HealthRecordSaver {
+
+    private final HealthChecker healthChecker;
+    private final HealthRecordRepository healthRecordRepository;
+    private final EntityFinder entityFinder;
+
+    public void saveRecord(Long serviceId){
+        Server server = entityFinder.findOrElseThrow(serviceId, Server.class);
+        try {
+            healthChecker.check(server);
+            healthRecordRepository.save(create(server,HealthStatus.SUCCESS));
+        }catch (HealthCheckException e){
+            healthRecordRepository.save(create(server,HealthStatus.FAIL));
+        }
+    }
+
+    private HealthRecord create(Server server, HealthStatus healthStatus){
+        return HealthRecord.builder()
+                .server(server)
+                .healthStatus(healthStatus)
+                .build();
+    }
+
+}

--- a/src/test/java/com/example/healthcheck/api/v1/controller/HealthCheckControllerTest.java
+++ b/src/test/java/com/example/healthcheck/api/v1/controller/HealthCheckControllerTest.java
@@ -1,0 +1,55 @@
+package com.example.healthcheck.api.v1.controller;
+
+import com.example.healthcheck.security.BringCustomer;
+import com.example.healthcheck.service.health.HealthRecordSaver;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(HealthCheckController.class)
+@AutoConfigureRestDocs(uriScheme = "https",uriHost = "api.health-check.com",uriPort = 443)
+@ExtendWith(RestDocumentationExtension.class)
+class HealthCheckControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private BringCustomer bringCustomer;
+
+    @MockBean
+    private HealthRecordSaver healthRecordSaver;
+
+    @Test
+    @DisplayName("[POST] [/api/v1/check/{serviceId}] 서버에 헬스 체크 테스트")
+    public void checkTest() throws Exception{
+
+        willDoNothing().given(healthRecordSaver).saveRecord(1L);
+
+        mockMvc.perform(post("/api/v1/check/{serverId}",1))
+                .andExpect(status().isOk())
+                .andExpect(handler().methodName("check"))
+                .andExpect(jsonPath("$.resultCode").value("SUCCESS"))
+                .andDo(document("check",
+                        pathParameters(parameterWithName("serverId").description("서버 아이디")),
+                        responseFields(fieldWithPath("resultCode").description("상태 코드"))));
+
+    }
+
+
+}

--- a/src/test/java/com/example/healthcheck/entity/server/ServerTest.java
+++ b/src/test/java/com/example/healthcheck/entity/server/ServerTest.java
@@ -1,0 +1,50 @@
+package com.example.healthcheck.entity.server;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+
+import java.util.List;
+
+class ServerTest {
+
+    @Test
+    @DisplayName("URL 만들기")
+    public void UriComponentsBuilderTest() throws Exception{
+        List<QueryParam> queryParams = List.of(createQueryParam("key","value"),createQueryParam("key","value2"));
+
+        Server server = createServer("https://service-hub.org","/service/search",toPrams(queryParams));
+
+        Assertions.assertThat(server.getUrl())
+                .isEqualTo("https://service-hub.org/service/search?key=value&key=value2");
+
+    }
+
+    private Server createServer(String host,String path,MultiValueMap<String,String> params){
+        return Server.builder()
+                .host(host)
+                .path(path)
+                .params(params)
+                .method(EndPointHttpMethod.GET)
+                .interval(30)
+                .active(true)
+                .build();
+    }
+
+    private MultiValueMap<String,String> toPrams(List<QueryParam> queryParams){
+        MultiValueMap<String,String> multiValueMap = new LinkedMultiValueMap<>();
+        for(var element : queryParams){
+            multiValueMap.add(element.getKey(),element.getValue());
+        }
+        return multiValueMap;
+    }
+
+    private QueryParam createQueryParam(String key,String value) {
+        return  QueryParam.builder()
+                .key(key)
+                .value(value)
+                .build();
+    }
+}

--- a/src/test/java/com/example/healthcheck/service/common/DefaultEntityFinderTest.java
+++ b/src/test/java/com/example/healthcheck/service/common/DefaultEntityFinderTest.java
@@ -1,0 +1,40 @@
+package com.example.healthcheck.service.common;
+
+import com.example.healthcheck.entity.server.EndPointHttpMethod;
+import com.example.healthcheck.entity.server.Server;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.util.LinkedMultiValueMap;
+
+class DefaultEntityFinderTest {
+
+    @Test
+    @DisplayName("EntityFinder 의 findOrElseThrow 테스트")
+    public void findOrElseThrow() throws Exception{
+
+        Assertions.assertThatCode(() -> findOrElseThrow(2L, Server.class))
+                .doesNotThrowAnyException();
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T> T findOrElseThrow(Long id, Class<T> clazz) {
+        return (T)find(id,clazz);
+    }
+
+    private <T> Object find(Long id, Class<T> clazz){
+        if(clazz.isAssignableFrom(Server.class)) return stubServer();
+        throw new IllegalStateException("지원하지 않는 클래스 타입입니다.");
+    }
+
+    private Server stubServer(){
+        return Server.builder()
+                .customerId(1L)
+                .method(EndPointHttpMethod.GET)
+                .interval(30)
+                .host("http://localhost:8080")
+                .active(true)
+                .params(new LinkedMultiValueMap<>())
+                .build();
+    }
+}

--- a/src/test/java/com/example/healthcheck/service/health/DefaultHealthCheckerMockTest.java
+++ b/src/test/java/com/example/healthcheck/service/health/DefaultHealthCheckerMockTest.java
@@ -1,0 +1,118 @@
+package com.example.healthcheck.service.health;
+
+import com.example.healthcheck.entity.server.Server;
+import com.example.healthcheck.exception.HealthCheckException;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.web.client.RestTemplate;
+
+import java.io.IOException;
+
+@SpringBootTest
+@ExtendWith(MockitoExtension.class)
+class DefaultHealthCheckerMockTest {
+
+    @Autowired
+    private HealthChecker defaultHealthChecker;
+
+    @Autowired
+    private RestTemplate restTemplate;
+
+    private MockWebServer mockWebServer;
+
+    @BeforeEach
+    void setup() throws IOException {
+        mockWebServer = new MockWebServer();
+        mockWebServer.start();
+    }
+
+    @AfterEach
+    void cleanup() throws IOException {
+        mockWebServer.shutdown();
+    }
+
+
+    @Test
+    @DisplayName("health check mockWebServer 성공 테스트")
+    public void health_check_mockWebServer_SUCCESS() throws Exception{
+        // given
+        String baseUrl = mockWebServer.url("/").toString();
+
+        Server server = stubServer(baseUrl);
+
+        // when
+        mockWebServer.enqueue(new MockResponse()
+                .setBody("ok")
+                .setResponseCode(200));
+
+        // then
+        Assertions.assertThatCode(() -> defaultHealthChecker.check(server))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("3번의 시도 중 마지막에 성공")
+    public void health_check_mockWebServer_SUCCESS_LAST() throws Exception{
+        // given
+        String baseUrl = mockWebServer.url("/").toString();
+
+        Server server = stubServer(baseUrl);
+
+        // when
+        mockWebServer.enqueue(new MockResponse()
+                .setResponseCode(400));
+
+        mockWebServer.enqueue(new MockResponse()
+                .setResponseCode(500));
+
+        mockWebServer.enqueue(new MockResponse()
+                .setResponseCode(200));
+
+        // then
+        Assertions.assertThatCode(() -> defaultHealthChecker.check(server))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("3번의 시도 모두 실패")
+    public void health_check_mockWebServer_FAIL() throws Exception{
+        // given
+        String baseUrl = mockWebServer.url("/").toString();
+
+        Server server = stubServer(baseUrl);
+
+        // when
+        mockWebServer.enqueue(new MockResponse()
+                .setResponseCode(400));
+
+        mockWebServer.enqueue(new MockResponse()
+                .setResponseCode(500));
+
+        mockWebServer.enqueue(new MockResponse()
+                .setResponseCode(500));
+
+        // then
+        Assertions.assertThatCode(() -> defaultHealthChecker.check(server))
+                .isInstanceOf(HealthCheckException.class);
+    }
+
+
+
+    private Server stubServer(String host){
+        return Server.builder()
+                .host(host)
+                .customerId(1L)
+                .active(true)
+                .interval(30)
+                .build();
+    }
+}

--- a/src/test/java/com/example/healthcheck/service/health/DefaultHealthCheckerTest.java
+++ b/src/test/java/com/example/healthcheck/service/health/DefaultHealthCheckerTest.java
@@ -1,0 +1,59 @@
+package com.example.healthcheck.service.health;
+
+import com.example.healthcheck.config.JpaConfig;
+import com.example.healthcheck.config.RetryConfig;
+import com.example.healthcheck.entity.server.Server;
+import com.example.healthcheck.exception.HealthCheckException;
+import com.example.healthcheck.repository.server.ServerRepository;
+import com.example.healthcheck.steps.ServerSteps;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.web.client.RestTemplate;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+@DataJpaTest
+@Import({DefaultHealthChecker.class, RestTemplate.class,
+        JpaConfig.class, RetryConfig.class})
+class DefaultHealthCheckerTest {
+
+    @Autowired
+    private HealthChecker healthChecker;
+    @Autowired
+    private ServerRepository serverRepository;
+    @Autowired
+    private RestTemplate template;
+    private ServerSteps serverSteps;
+
+    @BeforeEach
+    void setup(){
+        serverSteps = new ServerSteps(serverRepository);
+    }
+
+    @Test
+    @DisplayName("헬스 체킹 실패 테스트")
+    public void HealthChecker_check_SUCCESS() throws Exception{
+        // given
+        Server server = serverSteps.createNonexistentServer();
+        // expected
+        assertThatCode(()->healthChecker.check(server))
+                .isInstanceOf(HealthCheckException.class);
+    }
+
+    @Test
+    @DisplayName("헬스 체킹 성공 테스트")
+    public void HealthChecker_check_FAIL() throws Exception{
+        // given
+        Server server = serverSteps.createExistServer();
+
+        // expected
+        assertThatCode(()->healthChecker.check(server))
+                .doesNotThrowAnyException();
+    }
+
+
+}

--- a/src/test/java/com/example/healthcheck/service/health/HealthRecordSaverMockWebServerTest.java
+++ b/src/test/java/com/example/healthcheck/service/health/HealthRecordSaverMockWebServerTest.java
@@ -1,0 +1,124 @@
+package com.example.healthcheck.service.health;
+
+import com.example.healthcheck.entity.health.HealthRecord;
+import com.example.healthcheck.entity.health.HealthStatus;
+import com.example.healthcheck.entity.server.EndPointHttpMethod;
+import com.example.healthcheck.entity.server.Server;
+import com.example.healthcheck.repository.health.HealthRecordRepository;
+import com.example.healthcheck.repository.server.ServerRepository;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@Transactional
+class HealthRecordSaverMockWebServerTest {
+
+    @Autowired
+    private HealthRecordSaver healthRecordSaver;
+
+    private MockWebServer mockWebServer;
+
+    @Autowired
+    private ServerRepository serverRepository;
+
+    @Autowired
+    private HealthRecordRepository healthRecordRepository;
+
+    @BeforeEach
+    void setup() throws IOException {
+        mockWebServer = new MockWebServer();
+        mockWebServer.start();
+    }
+
+    @AfterEach
+    void cleanup() throws IOException {
+        mockWebServer.shutdown();
+    }
+
+    @Test
+    @DisplayName("헬스 체크 성공시 저장")
+    public void saveRecord_SUCCESS() throws Exception{
+        // given
+
+        String baseUrl = mockWebServer.url("/").toString();
+
+        Server server = serverRepository.save(stubServer(baseUrl));
+
+        // when
+
+        mockWebServer.enqueue(new MockResponse()
+                .setResponseCode(400));
+
+        mockWebServer.enqueue(new MockResponse()
+                .setBody("OK")
+                .setResponseCode(200));
+
+        healthRecordSaver.saveRecord(server.getId());
+
+
+        // then
+        HealthRecord healthRecord = healthRecordRepository
+                .findAll()
+                .stream()
+                .findAny()
+                .orElseThrow();
+
+        assertThat(healthRecord.getHealthStatus()).isEqualTo(HealthStatus.SUCCESS);
+
+    }
+
+    @Test
+    @DisplayName("헬스 체크 실패시 저장")
+    public void saveRecord_FAIL() throws Exception{
+
+        // given
+
+        String baseUrl = mockWebServer.url("/").toString();
+
+        Server server = serverRepository.save(stubServer(baseUrl));
+
+        // when
+
+        mockWebServer.enqueue(new MockResponse()
+                .setResponseCode(400));
+
+        mockWebServer.enqueue(new MockResponse()
+                .setResponseCode(400));
+
+        mockWebServer.enqueue(new MockResponse()
+                .setResponseCode(500));
+
+        healthRecordSaver.saveRecord(server.getId());
+
+
+        // then
+        HealthRecord healthRecord = healthRecordRepository
+                .findAll()
+                .stream()
+                .findAny()
+                .orElseThrow();
+
+        assertThat(healthRecord.getHealthStatus()).isEqualTo(HealthStatus.FAIL);
+    }
+
+    private Server stubServer(String host){
+        return Server.builder()
+                .host(host)
+                .customerId(1L)
+                .active(true)
+                .interval(30)
+                .method(EndPointHttpMethod.GET)
+                .build();
+    }
+}

--- a/src/test/java/com/example/healthcheck/service/health/HealthRecordSaverTest.java
+++ b/src/test/java/com/example/healthcheck/service/health/HealthRecordSaverTest.java
@@ -1,0 +1,96 @@
+package com.example.healthcheck.service.health;
+
+
+import com.example.healthcheck.config.JpaConfig;
+import com.example.healthcheck.config.RetryConfig;
+import com.example.healthcheck.entity.health.HealthRecord;
+import com.example.healthcheck.entity.health.HealthStatus;
+import com.example.healthcheck.entity.server.Server;
+import com.example.healthcheck.exception.HealthCheckException;
+import com.example.healthcheck.repository.health.HealthRecordRepository;
+import com.example.healthcheck.repository.server.ServerRepository;
+import com.example.healthcheck.service.common.DefaultEntityFinder;
+import com.example.healthcheck.steps.ServerSteps;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.mockito.BDDMockito.willThrow;
+
+@DataJpaTest
+@Import({
+        RetryConfig.class, JpaConfig.class,
+        DefaultEntityFinder.class,HealthRecordSaver.class,
+        DefaultHealthChecker.class
+})
+class HealthRecordSaverTest {
+
+    @Autowired
+    private HealthRecordSaver healthRecordSaver;
+
+    @MockBean
+    private HealthChecker healthChecker;
+
+    @Autowired
+    private ServerRepository serverRepository;
+
+    @Autowired
+    private HealthRecordRepository healthRecordRepository;
+    private ServerSteps serverSteps;
+
+    @BeforeEach
+    void setup(){
+        serverSteps = new ServerSteps(serverRepository);
+    }
+
+    @Test
+    @DisplayName("헬스 체크 성공시 저장")
+    public void saveRecord_SUCCESS() throws Exception{
+        // given
+        Server existServer = serverSteps.createExistServer();
+
+        willDoNothing().given(healthChecker).check(existServer);
+
+        // when
+        healthRecordSaver.saveRecord(existServer.getId());
+
+        // then
+        HealthRecord healthRecord = healthRecordRepository
+                .findAll()
+                .stream()
+                .findAny()
+                .orElseThrow();
+
+        assertThat(healthRecord.getHealthStatus()).isEqualTo(HealthStatus.SUCCESS);
+
+    }
+
+    @Test
+    @DisplayName("헬스 체크 실패시 저장")
+    public void saveRecord_FAIL() throws Exception{
+        // given
+        Server nonexistentServer = serverSteps.createNonexistentServer();
+
+        willThrow(HealthCheckException.class).given(healthChecker).check(nonexistentServer);
+
+        // when
+        healthRecordSaver.saveRecord(nonexistentServer.getId());
+
+        // then
+        HealthRecord healthRecord = healthRecordRepository
+                .findAll()
+                .stream()
+                .findAny()
+                .orElseThrow();
+
+        assertThat(healthRecord.getHealthStatus()).isEqualTo(HealthStatus.FAIL);
+
+    }
+
+}

--- a/src/test/java/com/example/healthcheck/steps/ServerSteps.java
+++ b/src/test/java/com/example/healthcheck/steps/ServerSteps.java
@@ -1,0 +1,49 @@
+package com.example.healthcheck.steps;
+
+import com.example.healthcheck.entity.server.EndPointHttpMethod;
+import com.example.healthcheck.entity.server.Server;
+import com.example.healthcheck.repository.server.ServerRepository;
+import org.springframework.util.LinkedMultiValueMap;
+
+public class ServerSteps {
+
+    private final ServerRepository serverRepository;
+
+    public ServerSteps(ServerRepository serverRepository) {
+        this.serverRepository = serverRepository;
+    }
+
+    public Server createDefault(){
+        return serverRepository.save(Server.builder()
+                .customerId(1L)
+                .method(EndPointHttpMethod.GET)
+                .interval(30)
+                .host("http://localhost:8080")
+                .active(true)
+                .params(new LinkedMultiValueMap<>())
+                .build());
+    }
+
+    public Server createNonexistentServer(){
+        return serverRepository.save(Server.builder()
+                .customerId(1L)
+                .method(EndPointHttpMethod.GET)
+                .interval(30)
+                .host("http://XXXX:8080")
+                .active(true)
+                .params(new LinkedMultiValueMap<>())
+                .build());
+    }
+
+    public Server createExistServer(){
+        return serverRepository.save(Server.builder()
+                .customerId(1L)
+                .method(EndPointHttpMethod.GET)
+                .interval(30)
+                .host("https://naver.com")
+                .active(true)
+                .params(new LinkedMultiValueMap<>())
+                .build());
+    }
+
+}


### PR DESCRIPTION
등록된 서버에 헬스 체킹 기능 구현

-  헬스 체크 레코드 Entity 정의
-  헬스 체크에 성공한 경우 성공으로 저장
-  헬스 체크에 실패한 경우 실패로 저장
-  헬스 체크에 실패한 경우 최대 3번 시도
-  테스트
-  REST Docs 문서화