### PR TITLE
헬스 체크 기능 구현

### DIFF
--- a/src/main/java/com/example/healthcheck/api/v1/controller/HealthCheckController.java
+++ b/src/main/java/com/example/healthcheck/api/v1/controller/HealthCheckController.java
@@ -2,18 +2,20 @@ package com.example.healthcheck.api.v1.controller;
 
 import com.example.healthcheck.api.v1.response.Response;
 import com.example.healthcheck.service.health.HealthCheckManager;
+import com.example.healthcheck.service.health.HealthCheckTimeExaminer;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.web.bind.annotation.*;
 
+@Slf4j
 @RestController
 @RequestMapping("/api/v1/check")
 @RequiredArgsConstructor
 public class HealthCheckController {
 
     private final HealthCheckManager healthCheckManager;
+    private final ObjectProvider<HealthCheckTimeExaminer> healthCheckTimeExaminers;
 
     @PostMapping("/{serverId}")
     public Response<Void> check(@PathVariable Long serverId){
@@ -21,5 +23,10 @@ public class HealthCheckController {
         return Response.success();
     }
 
-
+    @GetMapping
+    public Response<Void> check(){
+        HealthCheckTimeExaminer examiner = healthCheckTimeExaminers.getObject();
+        examiner.examine();
+        return Response.success();
+    }
 }

--- a/src/main/java/com/example/healthcheck/config/AppConfig.java
+++ b/src/main/java/com/example/healthcheck/config/AppConfig.java
@@ -3,13 +3,16 @@ package com.example.healthcheck.config;
 import com.example.healthcheck.service.alarm.AlarmSender;
 import com.example.healthcheck.service.alarm.MailAlarmSender;
 import com.example.healthcheck.service.alarm.MessageMaker;
+import com.example.healthcheck.util.Application;
 import lombok.RequiredArgsConstructor;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.web.client.RestTemplate;
 
 @Configuration
+@EnableConfigurationProperties(Application.class)
 @RequiredArgsConstructor
 public class AppConfig {
     private final JavaMailSender javaMailSender;

--- a/src/main/java/com/example/healthcheck/config/AsyncConfig.java
+++ b/src/main/java/com/example/healthcheck/config/AsyncConfig.java
@@ -1,0 +1,20 @@
+package com.example.healthcheck.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+@EnableAsync
+@Configuration
+public class AsyncConfig {
+
+    @Bean(name = "healthCheckTaskExecutor",destroyMethod = "shutdown")
+    public ThreadPoolTaskExecutor threadPoolExecutor(){
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(5);
+        executor.setMaxPoolSize(30);
+        executor.setQueueCapacity(50);
+        return executor;
+    }
+}

--- a/src/main/java/com/example/healthcheck/repository/health/HealthRecordRepository.java
+++ b/src/main/java/com/example/healthcheck/repository/health/HealthRecordRepository.java
@@ -1,7 +1,11 @@
 package com.example.healthcheck.repository.health;
 
 import com.example.healthcheck.entity.health.HealthRecord;
+import com.example.healthcheck.entity.server.Server;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface HealthRecordRepository extends JpaRepository<HealthRecord,Long> {
+    Optional<HealthRecord> findTopByServerOrderByCreatedAtDesc(Server server);
 }

--- a/src/main/java/com/example/healthcheck/repository/server/ServerRepository.java
+++ b/src/main/java/com/example/healthcheck/repository/server/ServerRepository.java
@@ -2,6 +2,14 @@ package com.example.healthcheck.repository.server;
 
 import com.example.healthcheck.entity.server.Server;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
 
 public interface ServerRepository extends JpaRepository<Server,Long> {
+
+    @Query("select s from Server s where s.active = true")
+    List<Server> findActiveServer();
 }
+
+

--- a/src/main/java/com/example/healthcheck/service/health/AsyncRequestHealthCheckSynchronizer.java
+++ b/src/main/java/com/example/healthcheck/service/health/AsyncRequestHealthCheckSynchronizer.java
@@ -1,0 +1,22 @@
+package com.example.healthcheck.service.health;
+
+import com.example.healthcheck.util.Application;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AsyncRequestHealthCheckSynchronizer implements HealthCheckSynchronizer{
+    private final Application application;
+    private final RestTemplate restTemplate;
+
+    @Override
+    @Async("healthCheckTaskExecutor")
+    public void synchronize() {
+        restTemplate.getForObject(application.getUrl(),String.class);
+    }
+}

--- a/src/main/java/com/example/healthcheck/service/health/HealthCheckAsync.java
+++ b/src/main/java/com/example/healthcheck/service/health/HealthCheckAsync.java
@@ -1,0 +1,22 @@
+package com.example.healthcheck.service.health;
+
+import com.example.healthcheck.util.Application;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class HealthCheckAsync {
+
+    private final Application application;
+    private final RestTemplate restTemplate;
+
+    @Async("healthCheckTaskExecutor")
+    public void process(){
+        restTemplate.getForObject(application.getUrl(),String.class);
+    }
+}

--- a/src/main/java/com/example/healthcheck/service/health/HealthCheckInitializer.java
+++ b/src/main/java/com/example/healthcheck/service/health/HealthCheckInitializer.java
@@ -1,0 +1,39 @@
+package com.example.healthcheck.service.health;
+
+import com.example.healthcheck.entity.health.HealthRecord;
+import com.example.healthcheck.entity.server.Server;
+import com.example.healthcheck.repository.health.HealthRecordRepository;
+import com.example.healthcheck.repository.server.ServerRepository;
+import com.example.healthcheck.service.health.dto.HealthCheckServer;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+import java.util.PriorityQueue;
+
+import static java.util.stream.Collectors.toCollection;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class HealthCheckInitializer {
+    private final ServerRepository serverRepository;
+    private final HealthRecordRepository healthRecordRepository;
+
+    public PriorityQueue<HealthCheckServer> getActiveServer(){
+        return serverRepository.findActiveServer()
+                .stream()
+                .map(this::covert)
+                .collect(toCollection(PriorityQueue::new));
+    }
+
+    private HealthCheckServer covert(Server server){
+        Optional<HealthRecord> recentlyRecord = healthRecordRepository.findTopByServerOrderByCreatedAtDesc(server);
+        return recentlyRecord
+                    .map(healthRecord -> HealthCheckServer.of(server, healthRecord.getCreatedAt()))
+                    .orElseGet(() -> HealthCheckServer.of(server, LocalDateTime.now()));
+    }
+
+}

--- a/src/main/java/com/example/healthcheck/service/health/HealthCheckManager.java
+++ b/src/main/java/com/example/healthcheck/service/health/HealthCheckManager.java
@@ -20,6 +20,7 @@ public class HealthCheckManager {
 
     public void check(Long serverId){
         Server server = entityFinder.findOrElseThrow(serverId, Server.class);
+        if(!server.isActive()) return;
         try {
             healthChecker.check(server);
             healthCheckSuccessManager.process(server);

--- a/src/main/java/com/example/healthcheck/service/health/HealthCheckRequester.java
+++ b/src/main/java/com/example/healthcheck/service/health/HealthCheckRequester.java
@@ -1,0 +1,5 @@
+package com.example.healthcheck.service.health;
+
+public interface HealthCheckRequester {
+    void check(Long serverId);
+}

--- a/src/main/java/com/example/healthcheck/service/health/HealthCheckSynchronizer.java
+++ b/src/main/java/com/example/healthcheck/service/health/HealthCheckSynchronizer.java
@@ -1,0 +1,5 @@
+package com.example.healthcheck.service.health;
+
+public interface HealthCheckSynchronizer {
+    void synchronize();
+}

--- a/src/main/java/com/example/healthcheck/service/health/HealthCheckTimeExaminer.java
+++ b/src/main/java/com/example/healthcheck/service/health/HealthCheckTimeExaminer.java
@@ -1,0 +1,5 @@
+package com.example.healthcheck.service.health;
+
+public interface HealthCheckTimeExaminer {
+    void examine();
+}

--- a/src/main/java/com/example/healthcheck/service/health/LocalQueueHealthCheckTimeExaminer.java
+++ b/src/main/java/com/example/healthcheck/service/health/LocalQueueHealthCheckTimeExaminer.java
@@ -1,0 +1,79 @@
+package com.example.healthcheck.service.health;
+
+import com.example.healthcheck.service.health.dto.CheckQueue;
+import com.example.healthcheck.service.health.dto.HealthCheckServer;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Scope;
+import org.springframework.stereotype.Service;
+
+import static com.example.healthcheck.util.TimeConverter.convertToLong;
+import static java.time.LocalDateTime.now;
+import static org.springframework.beans.factory.config.ConfigurableBeanFactory.SCOPE_PROTOTYPE;
+
+@Slf4j
+@Scope(value = SCOPE_PROTOTYPE)
+@Service
+@RequiredArgsConstructor
+public class LocalQueueHealthCheckTimeExaminer implements HealthCheckTimeExaminer{
+    private final static int UNIT_TIME = 1000 * 60;
+    private final static int SYNCHRONIZATION_TIME = 10;
+    private final HealthCheckInitializer healthCheckInitializer;
+    private final HealthCheckRequester healthCheckRequester;
+    private final HealthCheckSynchronizer healthCheckSynchronizer;
+    private CheckQueue queue;
+    private long time;
+    private long offset;
+
+    @Override
+    public void examine() {
+        init();
+        while(isContinue()){
+            sleep();
+            timePass();
+            checkQueue();
+        }
+        clear();
+        synchronizeQueue();
+    }
+
+    private void init(){
+        queue = new CheckQueue(healthCheckInitializer.getActiveServer());
+        offset = convertToLong(now());
+        time = offset;
+    }
+
+    private boolean isContinue(){
+        return time < SYNCHRONIZATION_TIME  + offset && queue.isNonEmpty();
+    }
+
+    private void sleep(){
+        try {
+            Thread.sleep(UNIT_TIME);
+        }catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private void timePass(){
+        this.time += 1;
+    }
+
+    private void checkQueue(){
+        while(queue.isCheckTime(time)){
+            HealthCheckServer server = queue.poll();
+            server.update();
+            queue.add(server);
+            healthCheckRequester.check(server.getServerId());
+        }
+    }
+
+    private void clear(){
+        queue.clear();
+    }
+
+    private void synchronizeQueue(){
+        healthCheckSynchronizer.synchronize();
+    }
+
+}

--- a/src/main/java/com/example/healthcheck/service/health/SynchronousInnerHealCheckRequester.java
+++ b/src/main/java/com/example/healthcheck/service/health/SynchronousInnerHealCheckRequester.java
@@ -1,0 +1,18 @@
+package com.example.healthcheck.service.health;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class SynchronousInnerHealCheckRequester implements HealthCheckRequester{
+
+    private final HealthCheckManager healthCheckManager;
+
+    @Override
+    public void check(Long serverId) {
+        healthCheckManager.check(serverId);
+    }
+}

--- a/src/main/java/com/example/healthcheck/service/health/dto/CheckQueue.java
+++ b/src/main/java/com/example/healthcheck/service/health/dto/CheckQueue.java
@@ -1,0 +1,41 @@
+package com.example.healthcheck.service.health.dto;
+
+import lombok.AllArgsConstructor;
+
+import java.util.PriorityQueue;
+
+@AllArgsConstructor
+public class CheckQueue {
+    private PriorityQueue<HealthCheckServer> queue;
+
+    public int size() {return queue.size();}
+    public boolean isNonEmpty(){
+        return !queue.isEmpty();
+    }
+
+    public HealthCheckServer peek(){
+        if(isNonEmpty()){
+            return queue.peek();
+        }
+        return null;
+    }
+
+    public boolean isCheckTime(long currentTime){
+        return peek().getCheckTime() == currentTime;
+    }
+
+    public HealthCheckServer poll(){
+        if(isNonEmpty()){
+            return queue.poll();
+        }
+        return null;
+    }
+
+    public void add(HealthCheckServer healthCheckServer){
+        queue.add(healthCheckServer);
+    }
+
+    public void clear(){
+        queue.clear();
+    }
+}

--- a/src/main/java/com/example/healthcheck/service/health/dto/HealthCheckServer.java
+++ b/src/main/java/com/example/healthcheck/service/health/dto/HealthCheckServer.java
@@ -1,0 +1,30 @@
+package com.example.healthcheck.service.health.dto;
+
+import com.example.healthcheck.entity.server.Server;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+import static com.example.healthcheck.util.TimeConverter.convertToLong;
+
+@Getter
+@AllArgsConstructor
+public class HealthCheckServer implements Comparable<HealthCheckServer>{
+    private long serverId;
+    private long checkTime;
+    private int interval;
+
+    public static HealthCheckServer of(Server server, LocalDateTime lastCheckTime){
+        return new HealthCheckServer(server.getId(), convertToLong(lastCheckTime) + server.getInterval(), server.getInterval());
+    }
+
+    public void update(){
+        checkTime += interval;
+    }
+
+    @Override
+    public int compareTo(HealthCheckServer that) {
+        return Long.compare(this.checkTime,that.checkTime);
+    }
+}

--- a/src/main/java/com/example/healthcheck/util/Application.java
+++ b/src/main/java/com/example/healthcheck/util/Application.java
@@ -1,0 +1,29 @@
+package com.example.healthcheck.util;
+
+import lombok.Data;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.web.util.UriComponentsBuilder;
+
+@Slf4j
+@Data
+@ConfigurationProperties("health-check")
+public class Application {
+
+    private final static String CHECK_ENDPOINT = "/api/v1/check";
+    private String schema;
+    private String host;
+    private String port;
+
+    public String getUrl(){
+        return UriComponentsBuilder.newInstance()
+                .scheme(schema)
+                .host(host)
+                .port(port)
+                .path(CHECK_ENDPOINT)
+                .encode()
+                .build()
+                .toString();
+    }
+
+}

--- a/src/main/java/com/example/healthcheck/util/TimeConverter.java
+++ b/src/main/java/com/example/healthcheck/util/TimeConverter.java
@@ -1,0 +1,31 @@
+package com.example.healthcheck.util;
+
+import java.time.LocalDateTime;
+
+import static java.time.Duration.between;
+
+public abstract class TimeConverter {
+
+    private static final LocalDateTime START = LocalDateTime.of(2023,5,1,0,0);
+    private static final long UNIT = 60;
+
+    private TimeConverter(){
+    }
+
+    public static LocalDateTime getStartDate(){
+        return START;
+    }
+
+    public static long getStartMinutes(){
+        return convertToLong(START);
+    }
+
+    public static long convertToLong(LocalDateTime dateTime) {
+        return between(START,dateTime).getSeconds() / UNIT;
+    }
+
+    public static LocalDateTime convertToLocalDateTime(long dateTime){
+        return START.plusMinutes(dateTime);
+    }
+
+}

--- a/src/test/java/com/example/healthcheck/repository/health/HealthRecordRepositoryTest.java
+++ b/src/test/java/com/example/healthcheck/repository/health/HealthRecordRepositoryTest.java
@@ -1,0 +1,80 @@
+package com.example.healthcheck.repository.health;
+
+import com.example.healthcheck.config.JpaConfig;
+import com.example.healthcheck.entity.health.HealthRecord;
+import com.example.healthcheck.entity.server.Server;
+import com.example.healthcheck.repository.server.ServerRepository;
+import com.example.healthcheck.steps.HealthRecordSteps;
+import com.example.healthcheck.steps.ServerSteps;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@Import(JpaConfig.class)
+class HealthRecordRepositoryTest {
+
+    @Autowired
+    private HealthRecordRepository healthRecordRepository;
+
+    @Autowired
+    private ServerRepository serverRepository;
+
+    private HealthRecordSteps healthRecordSteps;
+
+    private ServerSteps serverSteps;
+
+    @BeforeEach
+    void setup(){
+        healthRecordSteps = new HealthRecordSteps(healthRecordRepository);
+        serverSteps = new ServerSteps(serverRepository);
+    }
+
+    @Test
+    @DisplayName("서버에 대해 가장 최근에 실시한 헬스 체크 가져오기")
+    public void findTopByServerOrderByCreatedAtDescTest() throws Exception{
+        // given
+        Server server = serverSteps.createDefault();
+
+        HealthRecord firstRecord = healthRecordSteps.create(server);
+        Thread.sleep(100);
+        HealthRecord midRecord = healthRecordSteps.create(server);
+        Thread.sleep(100);
+        HealthRecord lastRecord = healthRecordSteps.create(server);
+
+        // when
+        Optional<HealthRecord> response = healthRecordRepository.findTopByServerOrderByCreatedAtDesc(server);
+
+        // then
+        assertThat(response).isPresent();
+        assertThat(response.get().getId()).isEqualTo(lastRecord.getId());
+
+    }
+
+    @Test
+    @DisplayName("여러 서버 중 특정 서버 대해 가장 최근에 실시한 헬스 체크 가져오기")
+    public void findTopByServerOrderByCreatedAtDescWithManyServer() throws Exception{
+        // given
+        Server server = serverSteps.createDefault();
+        Server other = serverSteps.createDefault();
+        healthRecordSteps.create(server);
+        HealthRecord lastRecord = healthRecordSteps.create(server);
+        healthRecordSteps.create(other);
+
+        // when
+        Optional<HealthRecord> response = healthRecordRepository.findTopByServerOrderByCreatedAtDesc(server);
+
+        // then
+        assertThat(response).isPresent();
+        assertThat(response.get().getId()).isEqualTo(lastRecord.getId());
+
+    }
+
+}

--- a/src/test/java/com/example/healthcheck/repository/server/ServerRepositoryTest.java
+++ b/src/test/java/com/example/healthcheck/repository/server/ServerRepositoryTest.java
@@ -1,0 +1,52 @@
+package com.example.healthcheck.repository.server;
+
+import com.example.healthcheck.config.JpaConfig;
+import com.example.healthcheck.entity.server.Server;
+import com.example.healthcheck.steps.ServerSteps;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+import java.util.List;
+
+import static java.util.stream.Collectors.toList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@Import(JpaConfig.class)
+class ServerRepositoryTest {
+
+
+    @Autowired
+    private ServerRepository serverRepository;
+
+    private ServerSteps serverSteps;
+
+    @BeforeEach
+    void setup(){
+        serverSteps = new ServerSteps(serverRepository);
+    }
+
+    @Test
+    @DisplayName("활성화된 서버만 조회하기")
+    public void findActiveServerTest() throws Exception{
+        // given
+        Server server = serverSteps.create("노말 서버",true);
+        Server enableServer = serverSteps.create("활성화된 서버",true);
+        Server disableServer = serverSteps.create("비활성화 서버",false);
+
+        // when
+        List<Server> response = serverRepository.findActiveServer();
+
+        // then
+        assertThat(response.size()).isEqualTo(2);
+        assertThat(response
+                .stream()
+                .map(Server::getServerName)
+                .collect(toList()))
+                .contains(server.getServerName() , enableServer.getServerName());
+    }
+}

--- a/src/test/java/com/example/healthcheck/service/health/HealthCheckInitializerTest.java
+++ b/src/test/java/com/example/healthcheck/service/health/HealthCheckInitializerTest.java
@@ -1,0 +1,62 @@
+package com.example.healthcheck.service.health;
+
+import com.example.healthcheck.config.JpaConfig;
+import com.example.healthcheck.entity.server.Server;
+import com.example.healthcheck.repository.health.HealthRecordRepository;
+import com.example.healthcheck.repository.server.ServerRepository;
+import com.example.healthcheck.service.health.dto.HealthCheckServer;
+import com.example.healthcheck.steps.ServerSteps;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+
+import java.util.PriorityQueue;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@Import({HealthCheckInitializer.class, JpaConfig.class})
+class HealthCheckInitializerTest {
+
+    @Autowired
+    private ServerRepository serverRepository;
+
+    @MockBean
+    private HealthRecordRepository healthRecordRepository;
+
+    @Autowired
+    private HealthCheckInitializer healthCheckInitializer;
+
+    private ServerSteps serverSteps;
+
+    @BeforeEach
+    void setup(){
+        serverSteps = new ServerSteps(serverRepository);
+    }
+
+    @Test
+    @DisplayName("활성화 된 서버를 먼저 체크되어야할 순으로 큐에 넣는다.")
+    public void getActiveServerTest() throws Exception{
+        //given
+        Server firstEnableServer = serverSteps.create("활성화 서버1", true,3);
+        Server secondEnableServer = serverSteps.create("활성화 서버2", true,4);
+        Server thirdEnableServer = serverSteps.create("활성화 서버3", true,2);
+        Server firstDisenableServer = serverSteps.create("비활성화 서버1", false);
+        Server secondDisableServer = serverSteps.create("비활성화 서버2", false);
+
+        //when
+        PriorityQueue<HealthCheckServer> queue = healthCheckInitializer.getActiveServer();
+
+
+        //then
+        assertThat(queue.size()).isEqualTo(3);
+        assertThat(queue.poll().getServerId()).isEqualTo(thirdEnableServer.getId());
+        assertThat(queue.poll().getServerId()).isEqualTo(firstEnableServer.getId());
+        assertThat(queue.poll().getServerId()).isEqualTo(secondEnableServer.getId());
+    }
+
+}

--- a/src/test/java/com/example/healthcheck/service/health/HealthCheckTriggerTest.java
+++ b/src/test/java/com/example/healthcheck/service/health/HealthCheckTriggerTest.java
@@ -1,0 +1,50 @@
+package com.example.healthcheck.service.health;
+
+import com.example.healthcheck.repository.server.ServerRepository;
+import com.example.healthcheck.steps.ServerSteps;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+@SpringBootTest
+class HealthCheckTriggerTest {
+
+    @MockBean
+    private HealthCheckManager healthCheckManager;
+
+    @Autowired
+    private HealthCheckAsync healthCheckAsync;
+
+    @Autowired
+    private HealthCheckInitializer healthCheckInitializer;
+
+    @Autowired
+    private ServerRepository serverRepository;
+
+    private ServerSteps serverSteps;
+
+    @BeforeEach
+    void setup(){
+        serverSteps = new ServerSteps(serverRepository);
+    }
+
+    @Test
+    @DisplayName("")
+    public void given_when_then() throws Exception{
+        // given
+        HealthCheckTrigger trigger = new HealthCheckTrigger(healthCheckManager,healthCheckAsync,healthCheckInitializer);
+
+        // when
+        trigger.process();
+
+        // then
+
+    }
+
+
+
+
+}

--- a/src/test/java/com/example/healthcheck/service/health/dto/HealthCheckServerTest.java
+++ b/src/test/java/com/example/healthcheck/service/health/dto/HealthCheckServerTest.java
@@ -1,0 +1,26 @@
+package com.example.healthcheck.service.health.dto;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+
+
+class HealthCheckServerTest {
+
+    @Test
+    @DisplayName("checkTime 테스트")
+    public void given_when_then() throws Exception{
+
+        LocalDateTime now = LocalDateTime.now();
+
+        LocalDateTime after30Minute = now.plusMinutes(30);
+
+        Assertions.assertThat(now.compareTo(after30Minute)).isLessThan(0);
+
+        Duration between = Duration.between(now,after30Minute);
+        Assertions.assertThat(between.getSeconds() / 60).isEqualTo(30);
+    }
+}

--- a/src/test/java/com/example/healthcheck/steps/HealthRecordSteps.java
+++ b/src/test/java/com/example/healthcheck/steps/HealthRecordSteps.java
@@ -1,0 +1,23 @@
+package com.example.healthcheck.steps;
+
+import com.example.healthcheck.entity.health.HealthRecord;
+import com.example.healthcheck.entity.health.HealthStatus;
+import com.example.healthcheck.entity.server.Server;
+import com.example.healthcheck.repository.health.HealthRecordRepository;
+
+public class HealthRecordSteps {
+
+    private final HealthRecordRepository healthRecordRepository;
+
+    public HealthRecordSteps(HealthRecordRepository healthRecordRepository) {
+        this.healthRecordRepository = healthRecordRepository;
+    }
+
+
+    public HealthRecord create(Server server){
+        return healthRecordRepository.save(HealthRecord.builder()
+                .server(server)
+                .healthStatus(HealthStatus.SUCCESS)
+                .build());
+    }
+}

--- a/src/test/java/com/example/healthcheck/steps/ServerSteps.java
+++ b/src/test/java/com/example/healthcheck/steps/ServerSteps.java
@@ -15,53 +15,36 @@ public class ServerSteps {
     }
 
     public static Server createStubServerWithDefaults(){
-        return Server.builder()
-                .serverName("디폴트 서버")
-                .email("email")
-                .method(EndPointHttpMethod.GET)
-                .interval(30)
-                .host("http://localhost:8080")
-                .active(true)
-                .params(new LinkedMultiValueMap<>())
+        return createDefaultBuilder()
                 .build();
     }
 
     public static Server createStubServerWithHost(String host){
-        return Server.builder()
-                .serverName("디폴트 서버")
-                .email("email")
-                .method(EndPointHttpMethod.GET)
-                .interval(30)
+        return createDefaultBuilder()
                 .host(host)
-                .active(true)
-                .params(new LinkedMultiValueMap<>())
                 .build();
     }
 
-    public static Server createStubServer(String host, String path,
-                                                      MultiValueMap<String,String> params){
-        return Server.builder()
-                .serverName("디폴트 서버")
-                .email("email")
-                .method(EndPointHttpMethod.GET)
-                .interval(30)
+    public static Server createStubServer(String host,
+                                          String path,
+                                          MultiValueMap<String,String> params){
+        return createDefaultBuilder()
                 .host(host)
                 .path(path)
-                .active(true)
                 .params(params)
                 .build();
     }
 
-    public Server createServer(String host){
-        return serverRepository.save(Server.builder()
-                .serverName("호스트를 지정한 서버")
-                .email("email")
+    private static Server.ServerBuilder createDefaultBuilder(){
+        return Server.builder()
+                .serverName("디폴트 서버 네임")
+                .email("test@test.com")
                 .method(EndPointHttpMethod.GET)
                 .interval(30)
-                .host(host)
-                .active(true)
+                .host("https://service-hub.org")
+                .path("/service/search")
                 .params(new LinkedMultiValueMap<>())
-                .build());
+                .active(true);
     }
 
     public Server createDefault(){
@@ -69,39 +52,43 @@ public class ServerSteps {
     }
 
     public Server createNonexistentServer(){
-        return serverRepository.save(Server.builder()
-                .serverName("존재하지 않는 서버")
-                .email("email")
-                .method(EndPointHttpMethod.GET)
-                .interval(30)
+        return save(createDefaultBuilder()
                 .host("http://XXXX:8080")
-                .active(true)
-                .params(new LinkedMultiValueMap<>())
+                .serverName("존재하지 않는 서버")
                 .build());
     }
 
     public Server createExistServer(){
-        return serverRepository.save(Server.builder()
+        return save(createDefaultBuilder()
                 .serverName("존재하는 서버")
-                .email("email")
-                .method(EndPointHttpMethod.GET)
-                .interval(30)
                 .host("https://naver.com")
-                .active(true)
-                .params(new LinkedMultiValueMap<>())
                 .build());
     }
 
     public Server createWithEmail(String email){
-        return serverRepository.save(Server.builder()
-                .serverName("존재하는 서버")
+        return save(createDefaultBuilder()
                 .email(email)
-                .method(EndPointHttpMethod.GET)
-                .interval(30)
-                .host("https://naver.com")
-                .active(true)
-                .params(new LinkedMultiValueMap<>())
                 .build());
     }
+
+    public Server create(String serverName,boolean isActive){
+        return save(createDefaultBuilder()
+                .serverName(serverName)
+                .active(isActive)
+                .build());
+    }
+
+    private Server save(Server server){
+        return serverRepository.save(server);
+    }
+
+    public Server create(String serverName,boolean isActive,int interval){
+        return save(createDefaultBuilder()
+                .serverName(serverName)
+                .active(isActive)
+                .interval(interval)
+                .build());
+    }
+
 
 }

--- a/src/test/java/com/example/healthcheck/util/ApplicationTest.java
+++ b/src/test/java/com/example/healthcheck/util/ApplicationTest.java
@@ -1,0 +1,24 @@
+package com.example.healthcheck.util;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+class ApplicationTest {
+
+    @Autowired
+    Application application;
+
+    @Test
+    @DisplayName("")
+    public void projectUtilTest() throws Exception{
+
+        assertThat(application.getUrl())
+                .isEqualTo("http://localhost:8080/api/v1/check");
+
+    }
+}

--- a/src/test/java/com/example/healthcheck/util/TimeConverterTest.java
+++ b/src/test/java/com/example/healthcheck/util/TimeConverterTest.java
@@ -1,0 +1,37 @@
+package com.example.healthcheck.util;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static com.example.healthcheck.util.TimeConverter.convertLocalDateTimeFrom;
+import static com.example.healthcheck.util.TimeConverter.convertToLong;
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+class TimeConverterTest {
+
+    @Test
+    @DisplayName("LocalDateTime 을 long 으로 변환")
+    public void LocalDateTimeToLong() throws Exception{
+        // given
+        LocalDateTime current = LocalDateTime.of(2023, 5, 2, 0, 0);
+        // when
+        long result = convertToLong(current);
+        // then
+        assertThat(result).isEqualTo(60 * 24);
+    }
+
+    @Test
+    @DisplayName("long 을 LocalDateTime 으로 변환")
+    public void longToLocalDateTime() throws Exception{
+        // given
+        long current = 60 * 24;
+        // when
+        LocalDateTime localDateTime = convertLocalDateTimeFrom(current);
+
+        // then
+        assertThat(localDateTime).isEqualTo(LocalDateTime.of(2023, 5, 2, 0, 0));
+    }
+}


### PR DESCRIPTION
1. 헬스 체크 대상인 활성화된 서버를 로컬 큐에 가져온다.
2. 1분마다 큐에 등록된 서버가 헬스 체크 대상인지 확인한다.
3. 헬스 체크 대상인 서버에 대해 동기방식으로 헬스 체크를 수행한다.
4. 30분마다 큐에 대한 동기화를 진행한다.
5. 동기화는 새로운 요청을 비동기 방식으로 요청하고 현재 쓰레드는 종료하고 새로운 요청의 스레드가 큐를 초기화하여 동기화하는 방식으로 구현.
